### PR TITLE
Add writeable flag for access depth array

### DIFF
--- a/jsk_perception/node_scripts/handheld_object_tracking.py
+++ b/jsk_perception/node_scripts/handheld_object_tracking.py
@@ -316,6 +316,7 @@ class HandHheldObjectTracking(object):
             rospy.logwarn('input msg is empty')
             return
 
+        depth.flags.writeable = True
         depth[np.isnan(depth)] = 0.0
 
         if self.rect is not None:


### PR DESCRIPTION
Add  writeable flag option because `cv_bridge.imgmsg_to_cv2` output array is not writeable. 
I got an error like below.
```
[ERROR] [1553855330.435608, 1497924864.713036] [/handheld_object_tracking:rosout]: bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7f142e465c50>>
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 75, in callback
    self.signalMessage(msg)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 57, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 291, in add
    self.signalMessage(*msgs)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 57, in signalMessage
    cb(*(msg + args))
  File "/home/taichi/annotation_ws/src/jsk_recognition/jsk_perception/node_scripts/handheld_object_tracking.py", line 320, in callback
    depth[np.isnan(depth)] = 0.0
ValueError: assignment destination is read-only
```