### PR TITLE
Avoid error when length of poly is 0

### DIFF
--- a/jsk_perception/node_scripts/ocr_node.py
+++ b/jsk_perception/node_scripts/ocr_node.py
@@ -226,9 +226,12 @@ class OCRNode(ConnectionBasedTransport):
             self.pub_debug_binary_viz.publish(msg_viz)
 
         # Sort the polygons in order of distance from the top left.
-        polys = np.array(polys, dtype=np.int32)
-        indices = np.argsort(polys.sum(axis=2).min(axis=1))
-        text = ' '.join([texts[i].decode('utf-8') for i in indices])
+        if len(polys) > 0:
+            polys = np.array(polys, dtype=np.int32)
+            indices = np.argsort(polys.sum(axis=2).min(axis=1))
+            text = ' '.join([texts[i].decode('utf-8') for i in indices])
+        else:
+            text = ''
         self.pub_str.publish(
             std_msgs.msg.String(data=text))
 
@@ -260,6 +263,7 @@ class OCRNode(ConnectionBasedTransport):
     def process_ocr(self, img, polys):
         texts = []
         imgs = []
+        binary_imgs = []
         if len(polys) > 0:
             n_jobs = min(self.n_jobs, len(polys))
             process = Pool(n_jobs)


### PR DESCRIPTION
When no character is found, I got the following error.
```
[ERROR] [1640356606.246070]: bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7f89eed33f50>>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/message_filters/__init__.py", line 76, in callback
    self.signalMessage(msg)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/message_filters/__init__.py", line 58, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/message_filters/__init__.py", line 225, in add
    self.signalMessage(*msgs)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/message_filters/__init__.py", line 58, in signalMessage
    cb(*(msg + args))
  File "/home/leus/ros/melodic/src/jsk-ros-pkg/jsk_recognition/jsk_perception/node_scripts/ocr_node.py", line 256, in polygons_callback
    texts, imgs, binary_imgs = self.process_ocr(img, polys)
  File "/home/leus/ros/melodic/src/jsk-ros-pkg/jsk_recognition/jsk_perception/node_scripts/ocr_node.py", line 281, in process_ocr
    return texts, imgs, binary_imgs
UnboundLocalError: local variable 'binary_imgs' referenced before assignment
```